### PR TITLE
Added AudioNodes to the list of DAWs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ This list is provided to help you build your own GNU/Linux based A/V production 
 -----------------------------------
 
 ## DAW/Sequencers
- * [AudioNodes](https://audionodes.com/) - Free, modular audio production suite with multi-track audio mixing, audio effects, parameter automation, MIDI editing, synthesis, cloud production, custom MIDI i/o, and more. `©`
-   * [AudioNodes Online](https://audionodes.com/online/) - Browser version.
  * **[VCV Rack](https://vcvrack.com/)** - Open-source virtual Eurorack DAW
  * **[ardour](http://www.ardour.org/)** - Digital Audio Workstation (DAW) and Multichannel Hard Disk Recorder (HDR) ([◼](https://packages.debian.org/sid/ardour))
  * [Helio workstation](https://helioworkstation.com/) - Free linear-based music For macOS, Linux, Windows, iOS and Android, with clean interface, version control, synchronization between devices, undo history, and more.  ([Source code](https://github.com/peterrudenko/helio-workstation/))
@@ -98,7 +96,7 @@ This list is provided to help you build your own GNU/Linux based A/V production 
  * [seq24](http://www.filter24.org/seq24/) - Real time MIDI sequencer ([◼](https://packages.debian.org/sid/seq24))
  * [friniika](http://www.frinika.com/) - A complete music workstation for Windows/Linux/OSX 
  * [Open Octave](http://www.openoctave.org/) - MIDI/Audio sequencer. ([Source](https://github.com/ccherrett/oom)) 
-
+ * [AudioNodes](https://audionodes.com/) - Free, modular audio production suite with multi-track audio mixing, audio effects, parameter automation, MIDI editing, synthesis, cloud production, custom MIDI i/o, and more. ([Browser version](https://audionodes.com/online/)) `©`
 
 ## Trackers
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ This list is provided to help you build your own GNU/Linux based A/V production 
 -----------------------------------
 
 ## DAW/Sequencers
+ * [AudioNodes](https://audionodes.com/) - Free, modular audio production suite with multi-track audio mixing, audio effects, parameter automation, MIDI editing, synthesis, cloud production, custom MIDI i/o, and more. `©`
+   * [AudioNodes Online](https://audionodes.com/online/) - Browser version.
  * **[VCV Rack](https://vcvrack.com/)** - Open-source virtual Eurorack DAW
  * **[ardour](http://www.ardour.org/)** - Digital Audio Workstation (DAW) and Multichannel Hard Disk Recorder (HDR) ([◼](https://packages.debian.org/sid/ardour))
  * [Helio workstation](https://helioworkstation.com/) - Free linear-based music For macOS, Linux, Windows, iOS and Android, with clean interface, version control, synchronization between devices, undo history, and more.  ([Source code](https://github.com/peterrudenko/helio-workstation/))


### PR DESCRIPTION
Hello,

I'd like to include [AudioNodes](https://audionodes.com) on this list. It's a free, modular audio production tool which I believe has a remarkable set of features for a free application, as well as a near-identical online version.

Features include audio mixing, audio effects composing, MIDI editing and generating, controller keyboard support, cloud production options, raw MIDI i/o, and audio visualization.

 - [Online demo](https://audionodes.com/online)
 - [Download (64-bit zip)](https://audionodes.com/download)

-----

![2017-12-06 12](https://user-images.githubusercontent.com/13468659/36370850-7019f580-1560-11e8-9b0d-be74197bf4cc.png)

**AudioNodes can be used primarily for:**

 - Audio mixing, there is an unlimited number of audio and envelope tracks, and clips can be freely moved between tracks
 - MIDI editing and MIDI-driven modular synthesis, AudioNodes has a lightweight piano roll in it, you might know this primarily from paid professional software
 - Effects processing and engineering, AudioNodes is modular and you can wire up effects in virtually unlimited combinations

There's also going to be an update likely this week or the next, with some new neat features, additions, and fixes.

**Technical specs**

 - 32 bit floating-point audio processing
 - 64 bit floating-point timing
 - Unlimited tracks and mixer channels, up to 32 audio channels
 - Modular architecture

**Closing word**

I hope this is a valuable and appropriate addition to this list, and I hope you'll find AudioNodes just as useful as many other people did before. What's funny is that this project was originally intended mainly for Windows users, but there are significantly more Linux users than Windows. :)

Thank you.

*Commit notes: I inserted AudioNodes at its alphabetical place, although the list seemed rather messy in this regard, so please edit its position if you feel it's not appropriate. Also, the contribution guidelines mentioned to mark an item with `x` if there is no debian package, although virtually every single item on the list uses an opposite strategy, marking debian packages with a square. Please edit it as you feel appropriate.*