### PR TITLE
Add 'go-dsp-guitar'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ List keys:
  * [freqtweak](http://freqtweak.sourceforge.net/) - Realtime audio frequency spectral manipulation ([◼](https://packages.debian.org/sid/freqtweak))
  * [g2reverb](https://kokkinizita.linuxaudio.org/linuxaudio/ladspa/) -reverb LADSPA plugin `▒`
  * [glitch](http://illformed.com/) - Multi-effects audio plugin with sequencer `©`
+ * [go-dsp-guitar](https://github.com/andrepxx/go-dsp-guitar) - A cross-platform effects processor / amp simulator for electric guitars and other instruments.  Supports JACK and remote control through web interface.
  * [guitarix](http://guitarix.sourceforge.net/) - Rock guitar amplifier for Jack (Standalone/LADSPA/LV2) ([◼](https://packages.debian.org/sid/guitarix)) `▒`
    * [gxplugins](https://github.com/brummer10/GxPlugins.lv2) - extra lv2 plugins from the guitarix project `▒`
  * [gxvoxtonebender](http://kxstudio.linuxaudio.org/Repositories:Plugins) - Fuzz Tonebender LV2 plugin `▒`


### PR DESCRIPTION
Add my own open-source project *go-dsp-guitar* to the list.

It provides a cross-platform (Windows, Linux, x86-64, ARM, ...) multi-effects processor for either real-time use with JACK, or, alternatively, standalone operation for processing RIFF WAVE / RF64 files.

Given the fact that *Rakarrack* and *Guitarix* are already listed, this seems like a natural addition (though I admit that the project ain't nearly that mature).

The main point that sets the project I suggest apart from the "competitors" is that it can be entirely remote-controlled by a web interface, enabling the "DSP machine" to operate in headless mode and control it from another machine (PC or mobile device) over the network. This enables an artist, say, to operate the "DSP" backstage and control it from a tablet on stage.

Since the web interface communicates with the actual DSP process by exchanging JSON messages, one could also relatively easily write bindings, which translate, say, MIDI events (or GPIO events on a *Raspberry Pi*) into parameter changes or bypass on/off actions, etc. so that parameters can be changed or effects could be bypassed / enabled via a footswitch controller (either MIDI controller or some buttons attached to GPIO lines), etc.