### PR TITLE
Add Tonalux Audio Analyzer (open source, in-browser)

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ List keys:
 * [spek](https://packages.debian.org/sid/spek) - acoustic spectrum analyser
 * [wolf-spectrum](https://github.com/wolf-plugins/wolf-spectrum) - Real-time 2D spectrogram plugin
 * [xoscope](http://xoscope.sourceforge.net/) - digital oscilloscope ([◼](https://packages.debian.org/sid/xoscope))
+* [Tonalux Audio Analyzer](https://tonalux.org/analyzer.html) - browser-based (works on Linux), open source ([MIT](https://github.com/Exenye/tonalux-analyzer)): LUFS/EBU R128, True Peak, BPM, key, spectrum, stereo correlation. Runs client-side, no upload.
 
 
 ### Audio utilities - Tuners & Metronomes


### PR DESCRIPTION
Adds the **Tonalux Audio Analyzer** — a free, open-source (MIT) audio analyzer that runs 100% in the browser, no upload: LUFS / EBU R128, True Peak, BPM, key, spectrum and stereo correlation.

Live: https://tonalux.org/analyzer.html
Source: https://github.com/Exenye/tonalux-analyzer

Happy to adjust formatting/section if needed.